### PR TITLE
Add puzzle explanations to board

### DIFF
--- a/src/components/game/Board.tsx
+++ b/src/components/game/Board.tsx
@@ -498,15 +498,18 @@ export function Board({ puzzle }: { puzzle: DailyPuzzle }) {
               backgroundColor: bgColors[group.difficulty]
             }}
           >
-            <span className="font-bold text-black/80 block text-center">
-              {group.name}
-            </span>
-            <div className="flex items-center gap-4 mt-1">
-              {group.emojis.map((emoji) => (
-                <span key={emoji} className="text-4xl">{emoji}</span>
-              ))}
-            </div>
-          </div>
+        <span className="font-bold text-black/80 block text-center">
+          {group.name}
+        </span>
+        <div className="flex items-center gap-4 mt-1">
+          {group.emojis.map((emoji) => (
+            <span key={emoji} className="text-4xl">{emoji}</span>
+          ))}
+        </div>
+        <p className="text-xs text-gray-700 mt-1 text-center px-2">
+          {group.explanation}
+        </p>
+      </div>
         ))}
 
         <AnimatePresence mode="wait">

--- a/src/components/game/ExpandingSolution.tsx
+++ b/src/components/game/ExpandingSolution.tsx
@@ -44,7 +44,7 @@ export function ExpandingSolution({
         DIFFICULTY_COLORS[solution.difficulty].solved
       )}
       style={{
-        height: tileSize + "px",
+        minHeight: tileSize + "px",
         transform: `translateY(${startRow * rowHeight}px)`,
         backgroundColor: bgColors[solution.difficulty]
       }}
@@ -61,6 +61,9 @@ export function ExpandingSolution({
           <span key={emoji} className="text-4xl">{emoji}</span>
         ))}
       </div>
+      <p className="text-xs text-gray-700 mt-1 text-center px-2">
+        {solution.explanation}
+      </p>
     </motion.div>
   );
-} 
+}

--- a/src/lib/puzzleGeneration.ts
+++ b/src/lib/puzzleGeneration.ts
@@ -186,10 +186,11 @@ OUTPUT **ONLY**:
     const shuffledEmojis = seededShuffle(allEmojis, puzzleId);
 
     return {
-      solutions: response.solutions.map(({ emojis, name, difficulty }) => ({
+      solutions: response.solutions.map(({ emojis, name, difficulty, explanation }) => ({
         emojis,
         name,
         difficulty,
+        explanation,
       })),
       emojis: shuffledEmojis,
     };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,6 +4,7 @@ export interface Solution {
   emojis: Emoji[];
   name: string;
   difficulty: 1 | 2 | 3 | 4;
+  explanation: string;
 }
 
 export interface GameState {


### PR DESCRIPTION
## Summary
- include explanation in Solution type
- persist explanations when generating puzzles
- show descriptions on board and reveal animation

## Testing
- `CI=1 npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run build` *(fails: unable to fetch Google Fonts during Next.js build)*